### PR TITLE
To allow manually trigger validation of recaptcha

### DIFF
--- a/views/components/initjs.blade.php
+++ b/views/components/initjs.blade.php
@@ -1,8 +1,14 @@
 <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?render={{$site_key??config('recaptcha-v3.site_key')}}"></script>
 <script>
-grecaptcha.ready(function() {
+grecaptcha.send = function() {
     grecaptcha.execute('{{$site_key??config('recaptcha-v3.site_key')}}', {action: '{{$action??''}}'}).then(function(token) {
         document.getElementById('{{ md5(($name ?? config('recaptcha-v3.input_name'))) }}').value = token;
+		document.dispatchEvent(new Event('grecaptcha.sent'));
     });
-});
+}
+@if($auto ?? true)
+	grecaptcha.ready(function() {
+		grecaptcha.send();
+	});
+@endif
 </script>


### PR DESCRIPTION
Developer can now @recaptcha_initjs(['auto' => false]) to init javascript which won't trigger grecaptcha.execute on grecaptcha.ready. This is useful when recaptcha should be only send when form is submitted, so that the validation of grecaptcha won't expired when form is submitted.

Reference: https://stackoverflow.com/questions/54437745/recaptcha-v3-how-to-deal-with-expired-token-after-idle